### PR TITLE
Renamed SELF to self for observing self.

### DIFF
--- a/BxPersistence/Properties/Property.swift
+++ b/BxPersistence/Properties/Property.swift
@@ -19,7 +19,7 @@ public struct Property<Value: PropertyType> {
     private let name: String?
     
     public var label: String {
-        return name ?? "SELF"
+        return name ?? "self"
     }
     
     public init<V>(_ name: String, relativeTo parent: Property<V>) {


### PR DESCRIPTION
Renamed SELF as it is not a valid keyPath for observing the object itself.